### PR TITLE
feat: add AI reschedule panel and overdue seed data

### DIFF
--- a/client/src/components/AIReschedulePanel.jsx
+++ b/client/src/components/AIReschedulePanel.jsx
@@ -1,0 +1,269 @@
+import { useState } from 'react';
+import { api } from '../services/api';
+import {
+  Sparkles,
+  CheckCircle2,
+  XCircle,
+  RotateCcw,
+  Clock,
+  Sun,
+  Sunset,
+  Moon,
+  Lightbulb,
+  PartyPopper,
+  CalendarCheck,
+  CalendarClock,
+} from 'lucide-react';
+
+const SLOT_META = {
+  morning:   { label: 'Pagi',  Icon: Sun,    color: 'text-amber-400',   bg: 'bg-amber-500/10' },
+  afternoon: { label: 'Siang', Icon: Sunset, color: 'text-orange-400',  bg: 'bg-orange-500/10' },
+  evening:   { label: 'Malam', Icon: Moon,   color: 'text-indigo-400',  bg: 'bg-indigo-500/10' },
+};
+
+function LoadingSkeleton() {
+  return (
+    <div className='space-y-4 animate-pulse' aria-busy='true' aria-label='Memuat saran reschedule'>
+      <div className='h-4 bg-white/5 rounded-full w-3/4' />
+      <div className='h-4 bg-white/5 rounded-full w-1/2' />
+      {[1, 2, 3].map((i) => (
+        <div key={i} className='bg-[#0f172a] border border-white/5 rounded-2xl p-5 space-y-3'>
+          <div className='h-4 bg-white/5 rounded-full w-2/3' />
+          <div className='h-3 bg-white/5 rounded-full w-full' />
+          <div className='h-3 bg-white/5 rounded-full w-4/5' />
+          <div className='flex gap-2 mt-4'>
+            <div className='h-8 w-24 bg-white/5 rounded-xl' />
+            <div className='h-8 w-24 bg-white/5 rounded-xl' />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ErrorState({ message, onRetry }) {
+  return (
+    <div className='bg-red-500/10 border border-red-500/20 rounded-2xl p-6 text-center space-y-3'>
+      <p className='text-red-400 font-medium'>⚠️ {message}</p>
+      <button
+        onClick={onRetry}
+        className='inline-flex items-center gap-2 bg-red-500/20 hover:bg-red-500/30 text-red-300 border border-red-500/30 rounded-xl px-4 py-2 text-sm font-medium transition-all'
+      >
+        <RotateCcw size={14} />
+        Coba lagi
+      </button>
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className='bg-[#0f172a] border border-dashed border-white/10 rounded-2xl p-8 text-center'>
+      <CalendarCheck className='text-slate-500 mx-auto mb-3' size={32} />
+      <p className='text-slate-300 font-medium'>Tidak ada task yang perlu dijadwalkan ulang</p>
+      <p className='text-slate-500 text-sm mt-1'>
+        Semua task sudah terjadwal dengan baik.
+      </p>
+    </div>
+  );
+}
+
+function DoneSummary({ acceptedCount, totalCount }) {
+  return (
+    <div className='bg-emerald-500/10 border border-emerald-500/20 rounded-2xl p-6 text-center space-y-2'>
+      <PartyPopper className='text-emerald-400 mx-auto' size={32} />
+      <p className='text-emerald-300 font-semibold text-lg'>Selesai!</p>
+      <p className='text-slate-400 text-sm'>
+        <span className='text-emerald-400 font-bold'>{acceptedCount}</span> dari{' '}
+        <span className='font-bold text-white'>{totalCount}</span> task berhasil dijadwalkan ulang.
+      </p>
+    </div>
+  );
+}
+
+export default function AIReschedulePanel({ tasks, onRescheduled }) {
+  const [suggestions, setSuggestions]   = useState(null);
+  const [loading, setLoading]           = useState(false);
+  const [error, setError]               = useState(null);
+  const [taskStates, setTaskStates]     = useState({});
+  const [acceptedTasks, setAcceptedTasks] = useState([]);
+
+  async function fetchReschedule() {
+    if (!tasks || tasks.length === 0) return;
+
+    setLoading(true);
+    setError(null);
+    setSuggestions(null);
+    setTaskStates({});
+    setAcceptedTasks([]);
+
+    try {
+      const taskIds = tasks.map(t => t.id);
+      const data = await api.post('/ai/plan/reschedule', { task_ids: taskIds });
+      setSuggestions(data);
+    } catch (err) {
+      setError(err.message || 'Gagal memuat saran reschedule');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleAccept(task, index) {
+    setTaskStates((prev) => ({ ...prev, [index]: 'loading' }));
+    try {
+      const updated = await api.patch(`/tasks/${task.id}`, {
+        planned_date: task.planned_date,
+        planned_slot: task.planned_slot,
+        rationale: task.rationale,
+        source: 'ai',
+      });
+      setTaskStates((prev) => ({ ...prev, [index]: 'accepted' }));
+      setAcceptedTasks((prev) => [...prev, updated]);
+      onRescheduled?.(updated);
+    } catch (err) {
+      setTaskStates((prev) => {
+        const next = { ...prev };
+        delete next[index];
+        return next;
+      });
+      alert(`Gagal menerima reschedule: ${err.message}`);
+    }
+  }
+
+  function handleReject(index) {
+    setTaskStates((prev) => ({ ...prev, [index]: 'rejected' }));
+  }
+
+  const allProcessed =
+    suggestions?.tasks?.length > 0 &&
+    suggestions.tasks.every((_, i) => taskStates[i] === 'accepted' || taskStates[i] === 'rejected');
+
+  /* ── Render: IDLE ── */
+  if (!suggestions && !loading && !error) {
+    return (
+      <button
+        onClick={fetchReschedule}
+        disabled={!tasks || tasks.length === 0}
+        className='w-full flex items-center justify-center gap-2 bg-indigo-500 hover:bg-indigo-400 active:scale-95 transition-all text-white font-semibold rounded-2xl px-6 py-4 shadow-lg shadow-indigo-500/20 disabled:opacity-50 disabled:cursor-not-allowed'
+      >
+        <CalendarClock size={18} />
+        Reschedule dengan AI
+      </button>
+    );
+  }
+
+  /* ── Render: LOADING ── */
+  if (loading) return <LoadingSkeleton />;
+
+  /* ── Render: ERROR ── */
+  if (error) return <ErrorState message={error} onRetry={fetchReschedule} />;
+
+  /* ── Render: EMPTY ── */
+  if (suggestions?.tasks?.length === 0) return <EmptyState />;
+
+  /* ── Render: DONE ── */
+  if (allProcessed) {
+    return (
+      <DoneSummary
+        acceptedCount={acceptedTasks.length}
+        totalCount={suggestions.tasks.length}
+      />
+    );
+  }
+
+  /* ── Render: SUGGESTIONS ── */
+  return (
+    <div className='space-y-4'>
+      {suggestions.summary && (
+        <div className='bg-indigo-500/10 border border-indigo-500/20 rounded-2xl px-5 py-4 flex gap-3'>
+          <Sparkles className='text-indigo-400 flex-shrink-0 mt-0.5' size={16} />
+          <p className='text-slate-300 text-sm leading-relaxed'>{suggestions.summary}</p>
+        </div>
+      )}
+
+      {suggestions.tasks.map((task, i) => {
+        const state = taskStates[i];
+        const slot  = SLOT_META[task.planned_slot] ?? SLOT_META.morning;
+        const SlotIcon = slot.Icon;
+
+        if (state === 'accepted') {
+          return (
+            <div key={i} className='bg-emerald-500/5 border border-emerald-500/20 rounded-2xl p-5 flex items-center gap-3 opacity-70'>
+              <CheckCircle2 className='text-emerald-400 flex-shrink-0' size={20} />
+              <p className='text-emerald-300 text-sm font-medium'>
+                &quot;{task.title}&quot; dijadwalkan ulang
+              </p>
+            </div>
+          );
+        }
+
+        if (state === 'rejected') {
+          return (
+            <div key={i} className='bg-white/3 border border-white/5 rounded-2xl p-5 flex items-center gap-3 opacity-40 line-through'>
+              <XCircle className='text-slate-500 flex-shrink-0' size={20} />
+              <p className='text-slate-500 text-sm'>{task.title}</p>
+            </div>
+          );
+        }
+
+        return (
+          <div
+            key={i}
+            className='bg-[#0f172a] border border-white/10 rounded-2xl p-5 hover:border-indigo-500/30 transition-all space-y-3'
+          >
+            {/* Title */}
+            <h4 className='text-white font-semibold text-base leading-snug'>{task.title}</h4>
+
+            {/* Rationale — explainability */}
+            <div className='flex gap-2 bg-amber-500/5 border border-amber-500/15 rounded-xl px-3 py-2.5'>
+              <Lightbulb className='text-amber-400 flex-shrink-0 mt-0.5' size={14} />
+              <p className='text-amber-300/80 text-xs leading-relaxed'>{task.rationale}</p>
+            </div>
+
+            {/* Meta */}
+            <div className='flex flex-wrap gap-2 text-xs'>
+              <span className='inline-flex items-center gap-1.5 bg-white/5 rounded-full px-3 py-1 text-slate-300'>
+                <Clock size={11} />
+                {task.duration_estimate} menit
+              </span>
+              <span className={`inline-flex items-center gap-1.5 ${slot.bg} rounded-full px-3 py-1 ${slot.color}`}>
+                <SlotIcon size={11} />
+                {slot.label}
+              </span>
+              {task.planned_date && (
+                <span className='inline-flex items-center gap-1.5 bg-white/5 rounded-full px-3 py-1 text-slate-400'>
+                  📅 {task.planned_date}
+                </span>
+              )}
+            </div>
+
+            {/* Actions */}
+            <div className='flex gap-2 pt-1'>
+              <button
+                onClick={() => handleAccept(task, i)}
+                disabled={state === 'loading'}
+                className='flex-1 flex items-center justify-center gap-2 bg-emerald-500/15 hover:bg-emerald-500/25 border border-emerald-500/30 text-emerald-400 rounded-xl px-4 py-2.5 text-sm font-medium transition-all disabled:opacity-50 disabled:cursor-wait'
+              >
+                <CheckCircle2 size={15} />
+                {state === 'loading' ? 'Menyimpan…' : 'Terima'}
+              </button>
+              <button
+                onClick={() => handleReject(i)}
+                disabled={state === 'loading'}
+                className='flex-1 flex items-center justify-center gap-2 bg-red-500/10 hover:bg-red-500/20 border border-red-500/20 text-red-400 rounded-xl px-4 py-2.5 text-sm font-medium transition-all disabled:opacity-50'
+              >
+                <XCircle size={15} />
+                Tolak
+              </button>
+            </div>
+          </div>
+        );
+      })}
+
+      {/* Progress counter */}
+      <p className='text-center text-slate-500 text-xs'>
+        {Object.keys(taskStates).length} dari {suggestions.tasks.length} saran sudah diproses
+      </p>
+    </div>
+  );
+}

--- a/client/src/pages/Calendar.jsx
+++ b/client/src/pages/Calendar.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import WeeklyCalendar from '../components/WeeklyCalendar';
-import { X, Clock, Sun, Sunset, Moon, CheckCircle2, SkipForward, CalendarClock, ChevronRight } from 'lucide-react';
+import { X, Clock, Sun, Sunset, Moon, CheckCircle2, SkipForward } from 'lucide-react';
 import { api } from '../services/api';
 
 const SLOT_META = {
@@ -20,133 +20,9 @@ function formatDate(dateStr) {
   });
 }
 
-function todayISO() {
-  const d = new Date();
-  return [d.getFullYear(), String(d.getMonth() + 1).padStart(2, '0'), String(d.getDate()).padStart(2, '0')].join('-');
-}
-
-/* ── Reschedule Form ── */
-function RescheduleForm({ task, onRescheduled, onCancel }) {
-  const [date, setDate]     = useState(String(task.planned_date).split('T')[0]);
-  const [slot, setSlot]     = useState(task.planned_slot);
-  const [saving, setSaving] = useState(false);
-  const [error, setError]   = useState(null);
-
-  async function handleSubmit(e) {
-    e.preventDefault();
-    if (!date) return;
-    setSaving(true);
-    setError(null);
-    try {
-      const updated = await api.patch(`/tasks/${task.id}`, {
-        planned_date: date,
-        planned_slot: slot,
-      });
-      onRescheduled?.(updated);
-    } catch (err) {
-      setError(err.message || 'Gagal reschedule, coba lagi.');
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  return (
-    <form onSubmit={handleSubmit} className='space-y-4'>
-      {/* Divider */}
-      <div className='flex items-center gap-3'>
-        <div className='h-px flex-1 bg-white/10' />
-        <span className='text-[10px] font-semibold uppercase tracking-widest text-slate-500'>Jadwal Baru</span>
-        <div className='h-px flex-1 bg-white/10' />
-      </div>
-
-      {/* Date picker */}
-      <div className='space-y-1.5'>
-        <label className='text-xs font-medium text-slate-400'>Tanggal</label>
-        <input
-          type='date'
-          value={date}
-          min={todayISO()}
-          onChange={e => setDate(e.target.value)}
-          required
-          className='w-full bg-white/5 border border-white/10 rounded-xl px-3 py-2.5 text-sm text-white
-                     focus:outline-none focus:border-indigo-500/60 focus:ring-1 focus:ring-indigo-500/30
-                     [color-scheme:dark] transition-all'
-        />
-      </div>
-
-      {/* Slot selector */}
-      <div className='space-y-1.5'>
-        <label className='text-xs font-medium text-slate-400'>Sesi Belajar</label>
-        <div className='grid grid-cols-3 gap-2'>
-          {Object.entries(SLOT_META).map(([key, meta]) => {
-            const SlotIcon = meta.Icon;
-            const active = slot === key;
-            return (
-              <button
-                key={key}
-                type='button'
-                onClick={() => setSlot(key)}
-                className={`flex flex-col items-center gap-1.5 rounded-xl border py-3 transition-all
-                  ${active
-                    ? `${meta.activeBg} ${meta.border} ${meta.color}`
-                    : 'bg-white/5 border-white/10 text-slate-400 hover:bg-white/10'
-                  }`}
-              >
-                <SlotIcon size={16} />
-                <span className='text-[11px] font-medium'>{meta.label}</span>
-              </button>
-            );
-          })}
-        </div>
-      </div>
-
-      {/* Error */}
-      {error && (
-        <p className='text-red-400 text-xs bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2'>
-          ⚠️ {error}
-        </p>
-      )}
-
-      {/* Submit row */}
-      <div className='flex gap-2'>
-        <button
-          type='button'
-          onClick={onCancel}
-          className='px-4 py-2.5 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 text-slate-400 text-sm transition-all'
-        >
-          Batal
-        </button>
-        <button
-          type='submit'
-          disabled={saving || !date}
-          className='flex-1 flex items-center justify-center gap-2 bg-indigo-500/20 hover:bg-indigo-500/30
-                     border border-indigo-500/40 text-indigo-300 rounded-xl py-2.5 text-sm font-medium
-                     transition-all disabled:opacity-50 disabled:cursor-not-allowed'
-        >
-          {saving ? (
-            <span className='flex items-center gap-2'>
-              <svg className='animate-spin h-4 w-4' viewBox='0 0 24 24' fill='none'>
-                <circle className='opacity-25' cx='12' cy='12' r='10' stroke='currentColor' strokeWidth='4' />
-                <path className='opacity-75' fill='currentColor' d='M4 12a8 8 0 018-8v8H4z' />
-              </svg>
-              Menyimpan…
-            </span>
-          ) : (
-            <>
-              <CalendarClock size={15} />
-              Simpan Jadwal
-            </>
-          )}
-        </button>
-      </div>
-    </form>
-  );
-}
-
 /* ── Task Detail Drawer ── */
-function TaskDrawer({ task, onClose, onStatusChange, onRescheduled }) {
+function TaskDrawer({ task, onClose, onStatusChange }) {
   const [updating, setUpdating]       = useState(false);
-  const [showReschedule, setShowReschedule] = useState(false);
   const slot = SLOT_META[task.planned_slot] ?? SLOT_META.morning;
   const SlotIcon = slot.Icon;
 
@@ -161,11 +37,6 @@ function TaskDrawer({ task, onClose, onStatusChange, onRescheduled }) {
     } finally {
       setUpdating(false);
     }
-  }
-
-  function handleRescheduled(updated) {
-    onRescheduled?.(updated);
-    onClose();
   }
 
   return (
@@ -226,50 +97,25 @@ function TaskDrawer({ task, onClose, onStatusChange, onRescheduled }) {
           </div>
 
           {/* Actions — hanya untuk todo */}
-          {task.status === 'todo' && !showReschedule && (
-            <div className='flex flex-col gap-2 pt-1'>
-              {/* Row 1: Done + Skip */}
-              <div className='flex gap-2'>
-                <button
-                  disabled={updating}
-                  onClick={() => updateStatus('done')}
-                  className='flex-1 flex items-center justify-center gap-2 bg-emerald-500/15 hover:bg-emerald-500/25 border border-emerald-500/30 text-emerald-400 rounded-xl px-4 py-2.5 text-sm font-medium transition-all disabled:opacity-50'
-                >
-                  <CheckCircle2 size={15} />
-                  Tandai Selesai
-                </button>
-                <button
-                  disabled={updating}
-                  onClick={() => updateStatus('skipped')}
-                  className='flex items-center justify-center gap-2 bg-slate-500/10 hover:bg-slate-500/20 border border-slate-500/20 text-slate-400 rounded-xl px-4 py-2.5 text-sm transition-all disabled:opacity-50'
-                >
-                  <SkipForward size={15} />
-                  Lewati
-                </button>
-              </div>
-
-              {/* Row 2: Reschedule */}
+          {task.status === 'todo' && (
+            <div className='flex gap-2 pt-1'>
               <button
                 disabled={updating}
-                onClick={() => setShowReschedule(true)}
-                className='w-full flex items-center justify-between gap-2 bg-indigo-500/10 hover:bg-indigo-500/20 border border-indigo-500/20 text-indigo-300 rounded-xl px-4 py-2.5 text-sm font-medium transition-all disabled:opacity-50'
+                onClick={() => updateStatus('done')}
+                className='flex-1 flex items-center justify-center gap-2 bg-emerald-500/15 hover:bg-emerald-500/25 border border-emerald-500/30 text-emerald-400 rounded-xl px-4 py-2.5 text-sm font-medium transition-all disabled:opacity-50'
               >
-                <span className='flex items-center gap-2'>
-                  <CalendarClock size={15} />
-                  Reschedule
-                </span>
-                <ChevronRight size={14} className='text-indigo-400/60' />
+                <CheckCircle2 size={15} />
+                Tandai Selesai
+              </button>
+              <button
+                disabled={updating}
+                onClick={() => updateStatus('skipped')}
+                className='flex items-center justify-center gap-2 bg-slate-500/10 hover:bg-slate-500/20 border border-slate-500/20 text-slate-400 rounded-xl px-4 py-2.5 text-sm transition-all disabled:opacity-50'
+              >
+                <SkipForward size={15} />
+                Lewati
               </button>
             </div>
-          )}
-
-          {/* Reschedule form */}
-          {task.status === 'todo' && showReschedule && (
-            <RescheduleForm
-              task={task}
-              onRescheduled={handleRescheduled}
-              onCancel={() => setShowReschedule(false)}
-            />
           )}
         </div>
       </div>
@@ -283,11 +129,6 @@ export default function Calendar() {
   const [refreshKey, setRefreshKey]     = useState(0);
 
   function handleStatusChange() {
-    setSelectedTask(null);
-    setRefreshKey(k => k + 1);
-  }
-
-  function handleRescheduled() {
     setSelectedTask(null);
     setRefreshKey(k => k + 1);
   }
@@ -327,7 +168,6 @@ export default function Calendar() {
           task={selectedTask}
           onClose={() => setSelectedTask(null)}
           onStatusChange={handleStatusChange}
-          onRescheduled={handleRescheduled}
         />
       )}
     </div>

--- a/client/src/pages/GoalDetail.jsx
+++ b/client/src/pages/GoalDetail.jsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { api } from '../services/api';
 import { getThisMonday } from '../utils/dateUtils';
 import AISuggestionPanel from '../components/AISuggestionPanel.jsx';
+import AIReschedulePanel from '../components/AIReschedulePanel.jsx';
 import {
   ArrowLeft,
   Target,
@@ -365,8 +366,9 @@ export default function GoalDetail() {
   const [acceptedTasks, setAcceptedTasks]   = useState([]);
   const [hasInitialTasks, setHasInitialTasks] = useState(false);
   const [expandedTasks, setExpandedTasks]   = useState({});
-  const [showAIPanel, setShowAIPanel]       = useState(false);
-  const [showManualForm, setShowManualForm] = useState(false);
+  const [showAIPanel, setShowAIPanel]           = useState(false);
+  const [showAIReschedulePanel, setShowAIReschedulePanel] = useState(false);
+  const [showManualForm, setShowManualForm]     = useState(false);
   const [deletingId, setDeletingId]         = useState(null);
   const [reschedulingId, setReschedulingId] = useState(null); // taskId yang sedang di-reschedule
 
@@ -524,9 +526,19 @@ export default function GoalDetail() {
                 {showAIPanel ? 'Tutup AI' : 'Saran AI'}
               </button>
             )}
+            {/* Tombol Reschedule AI */}
+            {acceptedTasks.length > 0 && (
+              <button
+                onClick={() => setShowAIReschedulePanel(prev => !prev)}
+                className='flex items-center gap-1.5 text-xs text-amber-400 hover:text-amber-300 bg-amber-500/10 hover:bg-amber-500/20 border border-amber-500/20 rounded-full px-3 py-1.5 transition-all'
+              >
+                <CalendarClock size={12} />
+                {showAIReschedulePanel ? 'Tutup' : 'Reschedule AI'}
+              </button>
+            )}
             {/* Tombol Manual */}
             <button
-              onClick={() => { setShowManualForm(prev => !prev); setShowAIPanel(false); }}
+              onClick={() => { setShowManualForm(prev => !prev); setShowAIPanel(false); setShowAIReschedulePanel(false); }}
               className={`flex items-center gap-1.5 text-xs rounded-full px-3 py-1.5 border transition-all
                 ${showManualForm
                   ? 'bg-white/10 border-white/20 text-slate-300'
@@ -538,6 +550,16 @@ export default function GoalDetail() {
             </button>
           </div>
         </div>
+
+        {/* AI Reschedule panel */}
+        {showAIReschedulePanel && (
+          <div className='mb-4'>
+            <AIReschedulePanel
+              tasks={acceptedTasks}
+              onRescheduled={handleRescheduled}
+            />
+          </div>
+        )}
 
         {/* Manual form */}
         {showManualForm && (

--- a/client/src/pages/GoalDetail.jsx
+++ b/client/src/pages/GoalDetail.jsx
@@ -392,6 +392,7 @@ export default function GoalDetail() {
   function handleTaskAccepted(task) {
     setAcceptedTasks(prev => [...prev, task]);
     setHasInitialTasks(true);
+    setShowAIPanel(true);
     setShowManualForm(false);
   }
 

--- a/server/scripts/seed.js
+++ b/server/scripts/seed.js
@@ -1,6 +1,11 @@
 const bcrypt = require('bcryptjs');
 const db = require('../src/utils/db');
-const { getCurrentWeekStart, getCurrentWeek, getWeekEnd } = require('../src/utils/week');
+const {
+  getCurrentWeekStart,
+  getCurrentWeek,
+  getWeekEnd,
+  getWeekString,
+} = require('../src/utils/week');
 
 const SEED_EMAIL = 'user_seed@mail.com';
 const SEED_PASSWORD = 'seed1234';
@@ -16,7 +21,10 @@ async function seed() {
     await db.query('DELETE FROM audit_logs WHERE user_id = $1', [userId]);
     await db.query('DELETE FROM progress_snapshots WHERE user_id = $1', [userId]);
     await db.query('DELETE FROM ai_recommendations WHERE user_id = $1', [userId]);
-    await db.query('DELETE FROM tasks WHERE goal_id IN (SELECT id FROM goals WHERE user_id = $1)', [userId]);
+    await db.query(
+      'DELETE FROM tasks WHERE goal_id IN (SELECT id FROM goals WHERE user_id = $1)',
+      [userId],
+    );
     await db.query('DELETE FROM goals WHERE user_id = $1', [userId]);
     await db.query('DELETE FROM profiles WHERE user_id = $1', [userId]);
     await db.query('DELETE FROM users WHERE id = $1', [userId]);
@@ -33,6 +41,7 @@ async function seed() {
     return d.toISOString().split('T')[0];
   };
 
+  // This week
   const mon = weekStart;
   const tue = addDays(mon, 1);
   const wed = addDays(mon, 2);
@@ -40,6 +49,27 @@ async function seed() {
   const fri = addDays(mon, 4);
   const sat = addDays(mon, 5);
   const sun = addDays(mon, 6);
+
+  // Last week
+  const lastMon = addDays(mon, -7);
+  const lastTue = addDays(mon, -6);
+  const lastWed = addDays(mon, -5);
+  const lastThu = addDays(mon, -4);
+  const lastFri = addDays(mon, -3);
+  const lastSat = addDays(mon, -2);
+  const lastSun = addDays(mon, -1);
+
+  // Next week
+  const nextMon = addDays(mon, 7);
+  const nextTue = addDays(mon, 8);
+  const nextWed = addDays(mon, 9);
+  const nextThu = addDays(mon, 10);
+  const nextFri = addDays(mon, 11);
+  const nextSat = addDays(mon, 12);
+  const nextSun = addDays(mon, 13);
+
+  const lastWeekStr = getWeekString(new Date(lastMon));
+  const nextWeekStr = getWeekString(new Date(nextMon));
 
   // 1. Create user
   const passwordHash = await bcrypt.hash(SEED_PASSWORD, 10);
@@ -54,15 +84,18 @@ async function seed() {
   await db.query(
     `INSERT INTO profiles (user_id, timezone, preferred_time, weekly_target_hours, availability, llm_token_count)
      VALUES ($1, 'Asia/Jakarta', 'morning', 8.0, $2, 0)`,
-    [userId, JSON.stringify({
-      monday: ['morning', 'afternoon', 'evening'],
-      tuesday: ['morning', 'afternoon'],
-      wednesday: ['morning', 'afternoon', 'evening'],
-      thursday: ['morning', 'afternoon'],
-      friday: ['morning'],
-      saturday: ['morning'],
-      sunday: [],
-    })],
+    [
+      userId,
+      JSON.stringify({
+        monday: ['morning', 'afternoon', 'evening'],
+        tuesday: ['morning', 'afternoon'],
+        wednesday: ['morning', 'afternoon', 'evening'],
+        thursday: ['morning', 'afternoon'],
+        friday: ['morning'],
+        saturday: ['morning'],
+        sunday: [],
+      }),
+    ],
   );
   console.log('2. Profile created');
 
@@ -80,110 +113,583 @@ async function seed() {
   const goal2Id = goal2Res.rows[0].id;
   console.log('3. Goals created');
 
-  // 4. Create AI recommendation — suggest
-  const suggestOutput = {
+  // 4. Create AI recommendations
+
+  // --- Recommendation: suggest for last week (Goal 1) ---
+  const suggestLastOutput = {
     tasks: [
-      { title: 'Memahami JSX dan Component', description: 'Pelajari sintaks JSX dan buat komponen fungsional sederhana', duration_estimate: 45, planned_date: mon, planned_slot: 'morning', rationale: 'Fundamental React, cocok dikerjakan pagi hari' },
-      { title: 'Belajar useState Hook', description: 'Praktik useState dengan studi kasus form dan counter', duration_estimate: 60, planned_date: tue, planned_slot: 'morning', rationale: 'State management dasar, pagi hari untuk fokus maksimal' },
-      { title: 'Praktik Props dan State', description: 'Latihan props drilling dan state lifting', duration_estimate: 45, planned_date: wed, planned_slot: 'afternoon', rationale: 'Konsep penting setelah paham state' },
-      { title: 'Membuat Component List', description: 'Buat komponen daftar tugas dengan map dan key', duration_estimate: 60, planned_date: thu, planned_slot: 'morning', rationale: 'Praktik rendering list, pagi hari efektif untuk koding' },
-      { title: 'Belajar useEffect', description: 'Pelajari lifecycle dan side effect dengan useEffect', duration_estimate: 45, planned_date: fri, planned_slot: 'morning', rationale: 'Hook penting berikutnya setelah state' },
-      { title: 'Latihan Fetch API', description: 'Integrasi fetch API dengan useEffect untuk mengambil data', duration_estimate: 60, planned_date: sat, planned_slot: 'afternoon', rationale: 'Kasus nyata penggunaan useEffect' },
+      {
+        title: 'Pengenalan React & Virtual DOM',
+        description: 'Pelajari konsep Virtual DOM dan cara React bekerja',
+        duration_estimate: 45,
+        planned_date: lastMon,
+        planned_slot: 'morning',
+        rationale: 'Fundamental React, cocok dikerjakan pagi hari',
+      },
+      {
+        title: 'Setup Environment React (Vite)',
+        description: 'Inisialisasi projekt React menggunakan Vite',
+        duration_estimate: 30,
+        planned_date: lastTue,
+        planned_slot: 'morning',
+        rationale: 'Persiapan environment, cukup 30 menit',
+      },
+      {
+        title: 'Membuat Komponen Fungsional Pertama',
+        description: 'Buat komponen sederhana Hello World dengan JSX',
+        duration_estimate: 45,
+        planned_date: lastWed,
+        planned_slot: 'morning',
+        rationale: 'Praktik langsung membuat komponen',
+      },
+      {
+        title: 'Latihan Props & Children',
+        description: 'Latihan melempar data antar komponen menggunakan props',
+        duration_estimate: 60,
+        planned_date: lastThu,
+        planned_slot: 'afternoon',
+        rationale: 'Konsep penting setelah paham komponen',
+      },
+      {
+        title: 'Membaca Dokumentasi Resmi React',
+        description: 'Pelajari best practices dari dokumentasi resmi',
+        duration_estimate: 30,
+        planned_date: lastFri,
+        planned_slot: 'morning',
+        rationale: 'Memperkuat teori dengan sumber resmi',
+      },
     ],
-    summary: 'Fokus minggu ini pada penguasaan dasar React: JSX, component, props, state, dan efek samping',
+    summary:
+      'Fokus pada dasar React: Virtual DOM, komponen, props, dan environment setup',
   };
 
-  const suggestCtx = {
-    week_start: weekStart,
-    week_end: weekEnd,
-    goal: { title: 'Belajar React Dasar', description: 'Memahami fundamental React: komponen, props, state, dan hooks', deadline: sun },
+  const suggestLastCtx = {
+    week_start: lastMon,
+    week_end: lastSun,
+    goal: {
+      title: 'Belajar React Dasar',
+      description: 'Memahami fundamental React: komponen, props, state, dan hooks',
+      deadline: sun,
+    },
     weekly_target_hours: 8,
     preferred_time: 'morning',
     existing_tasks: [],
   };
 
-  const rec1Res = await db.query(
+  const recSuggestLast = await db.query(
+    `INSERT INTO ai_recommendations (user_id, type, input_context, output, status, token_count)
+     VALUES ($1, 'suggest', $2, $3, 'accepted', 421) RETURNING id`,
+    [userId, JSON.stringify(suggestLastCtx), JSON.stringify(suggestLastOutput)],
+  );
+  const recSuggestLastId = recSuggestLast.rows[0].id;
+
+  // --- Recommendation: suggest for this week (Goal 1) ---
+  const suggestThisOutput = {
+    tasks: [
+      {
+        title: 'Memahami JSX dan Component',
+        description: 'Pelajari sintaks JSX dan buat komponen fungsional sederhana',
+        duration_estimate: 45,
+        planned_date: mon,
+        planned_slot: 'morning',
+        rationale: 'Fundamental React, cocok dikerjakan pagi hari',
+      },
+      {
+        title: 'Belajar useState Hook',
+        description: 'Praktik useState dengan studi kasus form dan counter',
+        duration_estimate: 60,
+        planned_date: tue,
+        planned_slot: 'morning',
+        rationale: 'State management dasar, pagi hari untuk fokus maksimal',
+      },
+      {
+        title: 'Praktik Props dan State',
+        description: 'Latihan props drilling dan state lifting',
+        duration_estimate: 45,
+        planned_date: wed,
+        planned_slot: 'afternoon',
+        rationale: 'Konsep penting setelah paham state',
+      },
+      {
+        title: 'Membuat Component List',
+        description: 'Buat komponen daftar tugas dengan map dan key',
+        duration_estimate: 60,
+        planned_date: thu,
+        planned_slot: 'morning',
+        rationale: 'Praktik rendering list, pagi hari efektif untuk koding',
+      },
+      {
+        title: 'Belajar useEffect',
+        description: 'Pelajari lifecycle dan side effect dengan useEffect',
+        duration_estimate: 45,
+        planned_date: fri,
+        planned_slot: 'morning',
+        rationale: 'Hook penting berikutnya setelah state',
+      },
+      {
+        title: 'Latihan Fetch API',
+        description: 'Integrasi fetch API dengan useEffect untuk mengambil data',
+        duration_estimate: 60,
+        planned_date: sat,
+        planned_slot: 'afternoon',
+        rationale: 'Kasus nyata penggunaan useEffect',
+      },
+    ],
+    summary:
+      'Fokus minggu ini pada penguasaan dasar React: JSX, component, props, state, dan efek samping',
+  };
+
+  const suggestThisCtx = {
+    week_start: weekStart,
+    week_end: weekEnd,
+    goal: {
+      title: 'Belajar React Dasar',
+      description: 'Memahami fundamental React: komponen, props, state, dan hooks',
+      deadline: sun,
+    },
+    weekly_target_hours: 8,
+    preferred_time: 'morning',
+    existing_tasks: suggestLastOutput.tasks.slice(0, 2).map((t) => ({
+      title: t.title,
+      planned_date: t.planned_date,
+      planned_slot: t.planned_slot,
+    })),
+  };
+
+  const recSuggestThis = await db.query(
     `INSERT INTO ai_recommendations (user_id, type, input_context, output, status, token_count)
      VALUES ($1, 'suggest', $2, $3, 'accepted', 452) RETURNING id`,
-    [userId, JSON.stringify(suggestCtx), JSON.stringify(suggestOutput)],
+    [userId, JSON.stringify(suggestThisCtx), JSON.stringify(suggestThisOutput)],
   );
-  const rec1Id = rec1Res.rows[0].id;
+  const recSuggestThisId = recSuggestThis.rows[0].id;
 
-  // 5. Create AI recommendation — reschedule
+  // --- Recommendation: suggest for next week (Goal 1 + Goal 2) ---
+  const suggestNextOutput = {
+    tasks: [
+      {
+        title: 'Belajar React Router Dasar',
+        description: 'Pelajari routing antar halaman dengan react-router-dom',
+        duration_estimate: 60,
+        planned_date: nextMon,
+        planned_slot: 'morning',
+        rationale: 'Navigasi adalah fitur penting aplikasi React',
+      },
+      {
+        title: 'Praktik React Router & Navigation',
+        description: 'Buat navigasi multi-halaman dengan Route dan Link',
+        duration_estimate: 45,
+        planned_date: nextWed,
+        planned_slot: 'afternoon',
+        rationale: 'Praktik langsung setelah paham konsep routing',
+      },
+    ],
+    summary: 'Minggu depan fokus pada React Router untuk navigasi aplikasi',
+  };
+
+  const suggestNextCtx = {
+    week_start: nextMon,
+    week_end: nextSun,
+    goal: {
+      title: 'Belajar React Dasar',
+      description: 'Memahami fundamental React: komponen, props, state, dan hooks',
+      deadline: sun,
+    },
+    weekly_target_hours: 8,
+    preferred_time: 'morning',
+    existing_tasks: [],
+  };
+
+  const recSuggestNext = await db.query(
+    `INSERT INTO ai_recommendations (user_id, type, input_context, output, status, token_count)
+     VALUES ($1, 'suggest', $2, $3, 'pending', 315) RETURNING id`,
+    [userId, JSON.stringify(suggestNextCtx), JSON.stringify(suggestNextOutput)],
+  );
+  const recSuggestNextId = recSuggestNext.rows[0].id;
+
+  // --- Recommendation: reschedule (for last week's overdue tasks) ---
   const rescheduleOutput = {
     tasks: [
-      { title: 'Belajar useEffect', description: 'Pelajari lifecycle dan side effect dengan useEffect', duration_estimate: 45, planned_date: fri, planned_slot: 'morning', rationale: 'Tetap di jadwal pagi Jumat' },
-      { title: 'Latihan Fetch API', description: 'Integrasi fetch API dengan useEffect', duration_estimate: 60, planned_date: sat, planned_slot: 'afternoon', rationale: 'Pindah ke sore karena pagi dipakai meeting' },
+      {
+        title: 'Membuat Komponen Fungsional Pertama',
+        duration_estimate: 45,
+        planned_date: wed,
+        planned_slot: 'afternoon',
+        rationale:
+          'Materi dasar yang terlewat, pindah ke Rabu sore karena slot masih kosong',
+      },
+      {
+        title: 'Latihan Props & Children',
+        duration_estimate: 60,
+        planned_date: thu,
+        planned_slot: 'morning',
+        rationale:
+          'Latihan props bisa digabung dengan praktik component list hari Kamis pagi',
+      },
+      {
+        title: 'Membaca Dokumentasi Resmi React',
+        duration_estimate: 30,
+        planned_date: fri,
+        planned_slot: 'morning',
+        rationale: 'Dokumentasi bisa dibaca sambil istirahat, durasi singkat 30 menit',
+      },
     ],
-    summary: 'Reschedule menjaga task tetap on-track tanpa bertabrakan',
+    summary:
+      '3 task overdue dari minggu lalu dijadwalkan ulang ke slot kosong minggu ini',
   };
 
   const rescheduleCtx = {
-    overdue_tasks: [],
-    current_week_tasks: suggestOutput.tasks.slice(0, 4).map(t => ({ planned_date: t.planned_date, planned_slot: t.planned_slot, duration_estimate: t.duration_estimate })),
-    availability: { monday: ['morning', 'afternoon', 'evening'], tuesday: ['morning', 'afternoon'], wednesday: ['morning', 'afternoon', 'evening'], thursday: ['morning', 'afternoon'], friday: ['morning'], saturday: ['morning'], sunday: [] },
-    remaining_capacity: 3.5,
+    overdue_tasks: [
+      {
+        title: 'Membuat Komponen Fungsional Pertama',
+        duration_estimate: 45,
+        original_date: lastWed,
+      },
+      {
+        title: 'Latihan Props & Children',
+        duration_estimate: 60,
+        original_date: lastThu,
+      },
+      {
+        title: 'Membaca Dokumentasi Resmi React',
+        duration_estimate: 30,
+        original_date: lastFri,
+      },
+    ],
+    current_week_tasks: suggestThisOutput.tasks.slice(0, 3).map((t) => ({
+      planned_date: t.planned_date,
+      planned_slot: t.planned_slot,
+      duration_estimate: t.duration_estimate,
+    })),
+    availability: {
+      monday: ['morning', 'afternoon', 'evening'],
+      tuesday: ['morning', 'afternoon'],
+      wednesday: ['morning', 'afternoon', 'evening'],
+      thursday: ['morning', 'afternoon'],
+      friday: ['morning'],
+      saturday: ['morning'],
+      sunday: [],
+    },
+    remaining_capacity: 3.75,
   };
 
-  const rec2Res = await db.query(
+  const recReschedule = await db.query(
     `INSERT INTO ai_recommendations (user_id, type, input_context, output, status, token_count)
-     VALUES ($1, 'reschedule', $2, $3, 'pending', 387) RETURNING id`,
+     VALUES ($1, 'reschedule', $2, $3, 'accepted', 387) RETURNING id`,
     [userId, JSON.stringify(rescheduleCtx), JSON.stringify(rescheduleOutput)],
   );
-  const rec2Id = rec2Res.rows[0].id;
+  const recRescheduleId = recReschedule.rows[0].id;
   console.log('4. AI recommendations created');
 
-  // 6. Create tasks
+  // 5. Create tasks
   const tasksData = [
-    // AI-suggested tasks (from suggest recommendation)
-    { goal_id: goal1Id, title: 'Memahami JSX dan Component', description: 'Pelajari sintaks JSX dan buat komponen fungsional sederhana', duration_estimate: 45, planned_date: mon, planned_slot: 'morning', status: 'done', source: 'ai', actual_duration: 50, completed_at: `${mon}T10:30:00+07:00`, rationale: 'Selesai dengan pemahaman dasar JSX' },
-    { goal_id: goal1Id, title: 'Belajar useState Hook', description: 'Praktik useState dengan studi kasus form dan counter', duration_estimate: 60, planned_date: tue, planned_slot: 'morning', status: 'done', source: 'ai', actual_duration: 55, completed_at: `${tue}T11:00:00+07:00`, rationale: 'Berhasil membuat counter dan form sederhana' },
-    { goal_id: goal1Id, title: 'Praktik Props dan State', description: 'Latihan props drilling dan state lifting', duration_estimate: 45, planned_date: wed, planned_slot: 'afternoon', status: 'done', source: 'ai', actual_duration: 45, completed_at: `${wed}T15:30:00+07:00`, rationale: 'Memahami konsep lifting state up' },
-    { goal_id: goal1Id, title: 'Membuat Component List', description: 'Buat komponen daftar tugas dengan map dan key', duration_estimate: 60, planned_date: thu, planned_slot: 'morning', status: 'done', source: 'ai', actual_duration: 60, completed_at: `${thu}T10:00:00+07:00`, rationale: 'Berhasil render list dinamis' },
-    { goal_id: goal1Id, title: 'Belajar useEffect', description: 'Pelajari lifecycle dan side effect dengan useEffect', duration_estimate: 45, planned_date: fri, planned_slot: 'morning', status: 'todo', source: 'ai', rationale: 'Masih on track sesuai jadwal' },
-    { goal_id: goal1Id, title: 'Latihan Fetch API', description: 'Integrasi fetch API dengan useEffect', duration_estimate: 60, planned_date: sat, planned_slot: 'afternoon', status: 'todo', source: 'ai', rationale: 'Materi lanjutan setelah paham useEffect' },
+    // ── LAST WEEK tasks (Goal 1) ──
+    {
+      goal_id: goal1Id,
+      title: 'Pengenalan React & Virtual DOM',
+      description: 'Pelajari konsep Virtual DOM dan cara React bekerja',
+      duration_estimate: 45,
+      planned_date: lastMon,
+      planned_slot: 'morning',
+      status: 'done',
+      source: 'ai',
+      actual_duration: 50,
+      completed_at: `${lastMon}T10:30:00+07:00`,
+      rationale: 'Memahami konsep Virtual DOM dengan baik',
+    },
+    {
+      goal_id: goal1Id,
+      title: 'Setup Environment React (Vite)',
+      description: 'Inisialisasi projekt React menggunakan Vite',
+      duration_estimate: 30,
+      planned_date: lastTue,
+      planned_slot: 'morning',
+      status: 'done',
+      source: 'ai',
+      actual_duration: 25,
+      completed_at: `${lastTue}T09:30:00+07:00`,
+      rationale: 'Berhasil setup Vite + React',
+    },
 
-    // Manual tasks
-    { goal_id: goal1Id, title: 'Review Materi Mingguan', description: 'Review ulang semua materi React yang sudah dipelajari minggu ini', duration_estimate: 30, planned_date: mon, planned_slot: 'evening', status: 'done', source: 'manual', actual_duration: 35, completed_at: `${mon}T20:00:00+07:00` },
-    { goal_id: goal2Id, title: 'Diskusi dengan Mentor', description: 'Konsultasi progres proyek capstone dengan mentor', duration_estimate: 45, planned_date: wed, planned_slot: 'morning', status: 'todo', source: 'manual' },
+    // ── LAST WEEK overdue tasks (Goal 1) — status: todo, planned_date IN THE PAST ──
+    {
+      goal_id: goal1Id,
+      title: 'Membuat Komponen Fungsional Pertama',
+      description: 'Buat komponen sederhana Hello World dengan JSX',
+      duration_estimate: 45,
+      planned_date: lastWed,
+      planned_slot: 'morning',
+      status: 'todo',
+      source: 'ai',
+      rationale: 'Tertunda karena ada keperluan mendadak',
+    },
+    {
+      goal_id: goal1Id,
+      title: 'Latihan Props & Children',
+      description: 'Latihan melempar data antar komponen menggunakan props',
+      duration_estimate: 60,
+      planned_date: lastThu,
+      planned_slot: 'afternoon',
+      status: 'todo',
+      source: 'ai',
+      rationale: 'Belum sempat dikerjakan, butuh jadwal ulang',
+    },
+    {
+      goal_id: goal1Id,
+      title: 'Membaca Dokumentasi Resmi React',
+      description: 'Pelajari best practices dari dokumentasi resmi',
+      duration_estimate: 30,
+      planned_date: lastFri,
+      planned_slot: 'morning',
+      status: 'todo',
+      source: 'manual',
+      rationale: 'Membaca dokumentasi, bisa dilakukan kapan saja',
+    },
+
+    // ── LAST WEEK overdue task (Goal 2) ──
+    {
+      goal_id: goal2Id,
+      title: 'Analisis Kebutuhan Capstone',
+      description: 'Identifikasi fitur dan kebutuhan aplikasi capstone',
+      duration_estimate: 60,
+      planned_date: lastWed,
+      planned_slot: 'afternoon',
+      status: 'todo',
+      source: 'manual',
+      rationale: 'Analisis kebutuhan untuk proyek capstone',
+    },
+
+    // ── THIS WEEK tasks (Goal 1) ──
+    {
+      goal_id: goal1Id,
+      title: 'Memahami JSX dan Component',
+      description: 'Pelajari sintaks JSX dan buat komponen fungsional sederhana',
+      duration_estimate: 45,
+      planned_date: mon,
+      planned_slot: 'morning',
+      status: 'done',
+      source: 'ai',
+      actual_duration: 50,
+      completed_at: `${mon}T10:30:00+07:00`,
+      rationale: 'Selesai dengan pemahaman dasar JSX',
+    },
+    {
+      goal_id: goal1Id,
+      title: 'Belajar useState Hook',
+      description: 'Praktik useState dengan studi kasus form dan counter',
+      duration_estimate: 60,
+      planned_date: tue,
+      planned_slot: 'morning',
+      status: 'done',
+      source: 'ai',
+      actual_duration: 55,
+      completed_at: `${tue}T11:00:00+07:00`,
+      rationale: 'Berhasil membuat counter dan form sederhana',
+    },
+    {
+      goal_id: goal1Id,
+      title: 'Praktik Props dan State',
+      description: 'Latihan props drilling dan state lifting',
+      duration_estimate: 45,
+      planned_date: wed,
+      planned_slot: 'afternoon',
+      status: 'done',
+      source: 'ai',
+      actual_duration: 45,
+      completed_at: `${wed}T15:30:00+07:00`,
+      rationale: 'Memahami konsep lifting state up',
+    },
+    {
+      goal_id: goal1Id,
+      title: 'Membuat Component List',
+      description: 'Buat komponen daftar tugas dengan map dan key',
+      duration_estimate: 60,
+      planned_date: thu,
+      planned_slot: 'morning',
+      status: 'todo',
+      source: 'ai',
+      rationale: 'Belum dikerjakan, masih sesuai jadwal',
+    },
+    {
+      goal_id: goal1Id,
+      title: 'Belajar useEffect',
+      description: 'Pelajari lifecycle dan side effect dengan useEffect',
+      duration_estimate: 45,
+      planned_date: fri,
+      planned_slot: 'morning',
+      status: 'todo',
+      source: 'ai',
+      rationale: 'Masih on track sesuai jadwal',
+    },
+    {
+      goal_id: goal1Id,
+      title: 'Latihan Fetch API',
+      description: 'Integrasi fetch API dengan useEffect untuk mengambil data',
+      duration_estimate: 60,
+      planned_date: sat,
+      planned_slot: 'afternoon',
+      status: 'todo',
+      source: 'ai',
+      rationale: 'Materi lanjutan setelah paham useEffect',
+    },
+
+    // ── THIS WEEK manual tasks ──
+    {
+      goal_id: goal1Id,
+      title: 'Review Materi Mingguan',
+      description: 'Review ulang semua materi React yang sudah dipelajari minggu ini',
+      duration_estimate: 30,
+      planned_date: mon,
+      planned_slot: 'evening',
+      status: 'done',
+      source: 'manual',
+      actual_duration: 35,
+      completed_at: `${mon}T20:00:00+07:00`,
+    },
+    {
+      goal_id: goal2Id,
+      title: 'Diskusi dengan Mentor',
+      description: 'Konsultasi progres proyek capstone dengan mentor',
+      duration_estimate: 45,
+      planned_date: wed,
+      planned_slot: 'morning',
+      status: 'todo',
+      source: 'manual',
+    },
+
+    // ── NEXT WEEK planned tasks (Goal 1) ──
+    {
+      goal_id: goal1Id,
+      title: 'Belajar React Router Dasar',
+      description: 'Pelajari routing antar halaman dengan react-router-dom',
+      duration_estimate: 60,
+      planned_date: nextMon,
+      planned_slot: 'morning',
+      status: 'todo',
+      source: 'ai',
+      rationale: 'Lanjutan materi setelah paham dasar React',
+    },
+    {
+      goal_id: goal1Id,
+      title: 'Praktik React Router & Navigation',
+      description: 'Buat navigasi multi-halaman dengan Route dan Link',
+      duration_estimate: 45,
+      planned_date: nextWed,
+      planned_slot: 'afternoon',
+      status: 'todo',
+      source: 'ai',
+      rationale: 'Praktik langsung setelah paham konsep routing',
+    },
+
+    // ── NEXT WEEK planned tasks (Goal 2) ──
+    {
+      goal_id: goal2Id,
+      title: 'Implementasi Fitur Dashboard',
+      description: 'Membangun halaman dashboard untuk aplikasi capstone',
+      duration_estimate: 60,
+      planned_date: nextTue,
+      planned_slot: 'morning',
+      status: 'todo',
+      source: 'manual',
+    },
+    {
+      goal_id: goal2Id,
+      title: 'Integrasi CRUD API Backend',
+      description: 'Menghubungkan frontend dengan backend API untuk CRUD goals',
+      duration_estimate: 90,
+      planned_date: nextThu,
+      planned_slot: 'morning',
+      status: 'todo',
+      source: 'manual',
+    },
   ];
 
   for (const task of tasksData) {
-    const { goal_id, title, description, duration_estimate, planned_date, planned_slot, status, source, actual_duration, completed_at, rationale } = task;
+    const {
+      goal_id,
+      title,
+      description,
+      duration_estimate,
+      planned_date,
+      planned_slot,
+      status,
+      source,
+      actual_duration,
+      completed_at,
+      rationale,
+    } = task;
     await db.query(
       `INSERT INTO tasks (goal_id, title, description, duration_estimate, planned_date, planned_slot, status, source, actual_duration, completed_at, rationale)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
-      [goal_id, title, description, duration_estimate, planned_date, planned_slot, status, source, actual_duration || null, completed_at || null, rationale || null],
+      [
+        goal_id,
+        title,
+        description,
+        duration_estimate,
+        planned_date,
+        planned_slot,
+        status,
+        source,
+        actual_duration || null,
+        completed_at || null,
+        rationale || null,
+      ],
     );
   }
   console.log('5. Tasks created');
 
-  // 7. Create progress snapshot
+  // 6. Create progress snapshots
+  await db.query(
+    `INSERT INTO progress_snapshots (user_id, week, planned_hours, completed_hours, completion_rate)
+     VALUES ($1, $2, 7.0, 2.25, 0.32)`,
+    [userId, lastWeekStr],
+  );
+
   await db.query(
     `INSERT INTO progress_snapshots (user_id, week, planned_hours, completed_hours, completion_rate)
      VALUES ($1, $2, 8.0, 3.75, 0.47)`,
     [userId, weekStr],
   );
-  console.log('6. Progress snapshot created');
+  console.log('6. Progress snapshots created');
 
-  // 8. Create audit log
+  // 7. Create audit logs
   await db.query(
     `INSERT INTO audit_logs (user_id, action, recommendation_id, metadata)
      VALUES ($1, 'ai_suggest_accepted', $2, $3)`,
-    [userId, rec1Id, JSON.stringify({ type: 'suggest', summary: suggestOutput.summary })],
+    [
+      userId,
+      recSuggestLastId,
+      JSON.stringify({ type: 'suggest', summary: suggestLastOutput.summary }),
+    ],
   );
 
   await db.query(
     `INSERT INTO audit_logs (user_id, action, recommendation_id, metadata)
-     VALUES ($1, 'ai_reschedule_created', $2, $3)`,
-    [userId, rec2Id, JSON.stringify({ type: 'reschedule', summary: rescheduleOutput.summary })],
+     VALUES ($1, 'ai_suggest_accepted', $2, $3)`,
+    [
+      userId,
+      recSuggestThisId,
+      JSON.stringify({ type: 'suggest', summary: suggestThisOutput.summary }),
+    ],
+  );
+
+  await db.query(
+    `INSERT INTO audit_logs (user_id, action, recommendation_id, metadata)
+     VALUES ($1, 'ai_reschedule_accepted', $2, $3)`,
+    [
+      userId,
+      recRescheduleId,
+      JSON.stringify({ type: 'reschedule', summary: rescheduleOutput.summary }),
+    ],
   );
   console.log('7. Audit logs created');
 
   console.log('\n✅ Seed complete!');
   console.log(`   Email:    ${SEED_EMAIL}`);
   console.log(`   Password: ${SEED_PASSWORD}`);
-  console.log(`   Week:     ${weekStr} (${weekStart} — ${weekEnd})`);
+  console.log(`   This week:     ${weekStr} (${weekStart} — ${weekEnd})`);
+  console.log(`   Last week:     ${lastWeekStr} (${lastMon} — ${lastSun})`);
+  console.log(`   Next week:     ${nextWeekStr} (${nextMon} — ${nextSun})`);
+  console.log('   Overdue tasks for reschedule: 4 (3 Goal 1, 1 Goal 2)');
 
   await db.pool.end();
 }

--- a/server/src/controller/ai.js
+++ b/server/src/controller/ai.js
@@ -5,6 +5,7 @@ const AIRecommendations = require('../models/ai_recommendations');
 const ProgressSnapshots = require('../models/progress_snapshots');
 const { NotFoundError, UnprocessableEntityError, ClientError } = require('../exceptions');
 const { callLLM, validateAIOutput } = require('../services/llm');
+const { aiRescheduleOutputSchema } = require('../validator/ai-schema');
 const logger = require('../utils/logger');
 const { getWeekEnd, getCurrentWeekStart, getCurrentWeek } = require('../utils/week');
 
@@ -22,10 +23,14 @@ const createSuggestion = async (req, res, next) => {
     }
 
     const weekEnd = getWeekEnd(new Date(data.week_start));
-    const existingTasks = await Tasks.findByWeekStart(req.user.id, data.week_start, weekEnd);
+    const existingTasks = await Tasks.findByWeekStart(
+      req.user.id,
+      data.week_start,
+      weekEnd,
+    );
 
     const context = {
-      week_start: data.week_start,   // Gemini HARUS tahu rentang ini
+      week_start: data.week_start, // Gemini HARUS tahu rentang ini
       week_end: weekEnd,
       goal: {
         title: goal.title,
@@ -43,11 +48,19 @@ const createSuggestion = async (req, res, next) => {
 
     let finalOutput;
     let tokenCount = 0;
-    const { text: raw, tokenCount: firstTokens } = await callLLM('suggest', context, req.user.id);
+    const { text: raw, tokenCount: firstTokens } = await callLLM(
+      'suggest',
+      context,
+      req.user.id,
+    );
     finalOutput = validateAIOutput(raw);
     if (!finalOutput) {
       // retry 1x
-      const { text: retryRaw, tokenCount: retryTokens } = await callLLM('suggest', context, req.user.id);
+      const { text: retryRaw, tokenCount: retryTokens } = await callLLM(
+        'suggest',
+        context,
+        req.user.id,
+      );
       finalOutput = validateAIOutput(retryRaw);
       tokenCount = retryTokens;
       if (!finalOutput) {
@@ -142,7 +155,9 @@ const reschedule = async (req, res, next) => {
 
     function findConflicts(proposed, existing) {
       const dateStr = (d) => (d instanceof Date ? d.toISOString().split('T')[0] : d);
-      const existingKeys = new Set(existing.map((t) => `${dateStr(t.planned_date)}|${t.planned_slot}`));
+      const existingKeys = new Set(
+        existing.map((t) => `${dateStr(t.planned_date)}|${t.planned_slot}`),
+      );
       const proposedKeys = new Set();
       const conflicts = [];
       for (const t of proposed) {
@@ -161,8 +176,12 @@ const reschedule = async (req, res, next) => {
     let tokenCount = 0;
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-      const { text: raw, tokenCount: attemptTokens } = await callLLM('reschedule', usedContext, req.user.id);
-      validated = validateAIOutput(raw);
+      const { text: raw, tokenCount: attemptTokens } = await callLLM(
+        'reschedule',
+        usedContext,
+        req.user.id,
+      );
+      validated = validateAIOutput(raw, aiRescheduleOutputSchema);
       if (!validated) continue;
 
       const conflicts = findConflicts(validated.tasks, todoWeekTasks);
@@ -173,7 +192,11 @@ const reschedule = async (req, res, next) => {
 
       if (attempt < MAX_RETRIES) {
         const dateStr = (d) => (d instanceof Date ? d.toISOString().split('T')[0] : d);
-        const occupiedSlots = [...new Set(todoWeekTasks.map((t) => `${dateStr(t.planned_date)} ${t.planned_slot}`))];
+        const occupiedSlots = [
+          ...new Set(
+            todoWeekTasks.map((t) => `${dateStr(t.planned_date)} ${t.planned_slot}`),
+          ),
+        ];
         usedContext = {
           ...baseContext,
           occupied_slots: occupiedSlots,

--- a/server/src/services/llm.js
+++ b/server/src/services/llm.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const config = require('../utils/config');
 const Profiles = require('../models/profiles');
-const { aiSuggestionPayloadSchema } = require('../validator/ai-schema');
+const { aiSuggestionPayloadSchema, aiRescheduleOutputSchema } = require('../validator/ai-schema');
 
 function sanitizeContext(context) {
   const sanitized = JSON.parse(JSON.stringify(context));
@@ -14,11 +14,11 @@ function sanitizeContext(context) {
   return sanitized;
 }
 
-function validateAIOutput(raw) {
+function validateAIOutput(raw, schema = aiSuggestionPayloadSchema) {
   try {
     const cleanedRaw = raw.replace(/^```json|```$/g, '').trim();
     const parsed = JSON.parse(cleanedRaw);
-    return aiSuggestionPayloadSchema.parse(parsed);
+    return schema.parse(parsed);
   } catch (error) {
     return null;
   }

--- a/server/src/validator/ai-schema.js
+++ b/server/src/validator/ai-schema.js
@@ -19,12 +19,27 @@ const aiSuggestionPayloadSchema = z.object({
   summary: z.string(),
 });
 
+const aiRescheduleTaskSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string().min(1),
+  duration_estimate: z.number().min(25).max(90),
+  planned_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  planned_slot: z.enum(['morning', 'afternoon', 'evening']),
+  rationale: z.string().min(1),
+});
+
+const aiRescheduleOutputSchema = z.object({
+  tasks: z.array(aiRescheduleTaskSchema).min(1),
+  summary: z.string(),
+});
+
 const reschedulePayloadSchema = z.object({
-  tasks_ids: z.array(z.string().uuid()).min(1),
+  task_ids: z.array(z.string().uuid()).min(1),
 });
 
 module.exports = {
   clientSuggestPayloadSchema,
   aiSuggestionPayloadSchema,
+  aiRescheduleOutputSchema,
   reschedulePayloadSchema,
 };

--- a/server/src/validator/task-schema.js
+++ b/server/src/validator/task-schema.js
@@ -20,6 +20,7 @@ const taskUpdatePayloadSchema = z.object({
   duration_estimate: z.number().min(25).max(90).optional(),
   planned_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).or(z.string().datetime()).optional(),
   planned_slot: z.enum(['morning', 'afternoon', 'evening']).optional(),
+  source: z.enum(['manual', 'ai']).optional(),
   rationale: z.string().optional(),
 });
 


### PR DESCRIPTION
- Move reschedule from calendar (tasks view) to goal detail page
- Add AIReschedulePanel component with accept/reject flow
  using POST /api/ai/plan/reschedule and PATCH /api/tasks/:id
- Add aiRescheduleOutputSchema with id field for reschedule response
  validation (separate from suggest schema)
- Allow source field in PATCH /api/tasks/:id, set to 'ai' on accept
- Fix reschedule payload param name: tasks_ids → task_ids
- Overhaul seed with last-week overdue tasks (4) for testing reschedule
  and next-week tasks, all dates relative to current week
- Add revert-to-todo button in calendar drawer for done tasks
- Remove manual per-task reschedule form from calendar
