### PR TITLE
be/test and improvements

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -41,7 +41,12 @@
     "collectCoverageFrom": [
       "src/**/*.js",
       "!src/index.js"
-    ]
+    ],
+    "coverageThreshold": {
+      "global": {
+        "lines": 50
+      }
+    }
   },
   "prettier": {
     "singleQuote": true,

--- a/server/src/routes/ai.js
+++ b/server/src/routes/ai.js
@@ -32,11 +32,4 @@ router.patch('/recommendations/:id', authenticate, editRecommendationById);
 
 router.get('/token-usage', authenticate, getTokenUsage);
 
-/**
- * POST /api/ai/plan/reschedule
- * Body: { task_ids: string[] } — array UUID task yang overdue
- * Meminta AI untuk menjadwalkan ulang task overdue ke minggu berjalan.
- */
-router.post('/plan/reschedule', authenticate, reschedule);
-
 module.exports = router;

--- a/server/src/services/llm.js
+++ b/server/src/services/llm.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const config = require('../utils/config');
 const Profiles = require('../models/profiles');
-const { aiSuggestionPayloadSchema, aiRescheduleOutputSchema } = require('../validator/ai-schema');
+const { aiSuggestionPayloadSchema } = require('../validator/ai-schema');
 
 function sanitizeContext(context) {
   const sanitized = JSON.parse(JSON.stringify(context));
@@ -16,8 +16,9 @@ function sanitizeContext(context) {
 
 function validateAIOutput(raw, schema = aiSuggestionPayloadSchema) {
   try {
-    const cleanedRaw = raw.replace(/^```json|```$/g, '').trim();
-    const parsed = JSON.parse(cleanedRaw);
+    // const cleanedRaw = raw.replace(/^```json|```$/g, '').trim();
+    // const parsed = JSON.parse(cleanedRaw);
+    const parsed = typeof raw === 'object' ? raw : JSON.parse(raw.replace(/^```json\s*|\s*```$/g, '').trim());
     return schema.parse(parsed);
   } catch (error) {
     return null;

--- a/server/tests/ai.test.js
+++ b/server/tests/ai.test.js
@@ -67,47 +67,87 @@ beforeAll(async () => {
 });
 
 describe('validateAIOutput()', () => {
+  const validTask = {
+    title: 'Initial Brainstorm & Topic Mapping for Test',
+    description:
+      'Dedicate time to recall and list all major topics and sub-topics expected on the test. Create a mind map or outline to visualize connections and identify initial areas of strength and weakness.',
+    duration_estimate: 60,
+    planned_date: '2023-10-26',
+    planned_slot: 'morning',
+    rationale:
+      'Starting with a comprehensive overview helps in understanding the scope of the test and proactively mapping out the study journey. A morning slot is often best for tasks requiring focused recall and organization.',
+  };
+
   test('should return a correct schema', async () => {
-    const raw = `\`\`\`json
-{
-  "tasks": [
-    {
-      "title": "Initial Brainstorm & Topic Mapping for Test",
-      "description": "Dedicate time to recall and list all major topics and sub-topics expected on the test. Create a mind map or outline to visualize connections and identify initial areas of strength and weakness.",
-      "duration_estimate": 60,
-      "planned_date": "2023-10-26",
-      "planned_slot": "morning",
-      "rationale": "Starting with a comprehensive overview helps in understanding the scope of the test and proactively mapping out the study journey. A morning slot is often best for tasks requiring focused recall and organization."
-    }
-  ],
-  "summary": "This initial plan for your 'test' goal focuses on structured preparation."
-}
-\`\`\``;
-    const validated = validateAIOutput(raw);
-    const result = aiSuggestionPayloadSchema.safeParse(validated);
-    expect(result.success).toBe(true);
+    const raw = {
+      tasks: [validTask],
+      summary:
+        "This initial plan for your 'test' goal focuses on structured preparation.",
+    };
+
+    const result = validateAIOutput(raw);
+    expect(result).not.toBeNull();
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0].title).toBe('Initial Brainstorm & Topic Mapping for Test');
   });
 
   test('should return error details if schema is wrong', async () => {
     const raw = `\`\`\`json
-{
-  "tasks": [
-    {
-      "title": "",
-      "description": "Dedicate time to recall and list all major topics.",
-      "duration_estimate": 60,
-      "planned_date": "2023-10-26",
-      "planned_slot": "midnight",
-      "rationale": "Starting with a comprehensive overview helps in understanding the scope of the test."
-    }
-  ],
-  "summary": "This initial plan for your 'test' goal focuses on structured preparation."
-}
-\`\`\``;
-    const validated = validateAIOutput(raw);
-    const result = aiSuggestionPayloadSchema.safeParse(validated);
-    expect(result.success).toBe(false);
-    expect(result.error.issues.length).toBeGreaterThan(0);
+          {
+            "tasks": [
+              {
+                "title": "",
+                "description": "Dedicate time to recall and list all major topics.",
+                "duration_estimate": 60,
+                "planned_date": "2023-10-26",
+                "planned_slot": "midnight",
+                "rationale": "Starting with a comprehensive overview helps in understanding the scope of the test."
+              }
+            ],
+            "summary": "This initial plan for your 'test' goal focuses on structured preparation."
+          }
+          \`\`\``;
+    expect(validateAIOutput(raw)).toBeNull();
+  });
+
+  test('should reject under 25 minute duration', async () => {
+    const raw = {
+      tasks: [{ ...validTask, duration_estimate: 10 }],
+      summary: 'test',
+    };
+    expect(validateAIOutput(raw)).toBeNull();
+  });
+
+  test('should reject over 90 minute duration', async () => {
+    const raw = {
+      tasks: [{ ...validTask, duration_estimate: 100 }],
+      summary: 'test',
+    };
+    expect(validateAIOutput(raw)).toBeNull();
+  });
+
+  test('should reject response without rationale', async () => {
+    const raw = {
+      tasks: [{ ...validTask, rationale: '' }],
+      summary: 'test',
+    };
+    expect(validateAIOutput(raw)).toBeNull();
+  });
+
+  test('should reject invalid planned_slot', async () => {
+    const raw = {
+      tasks: [{ ...validTask, planned_slot: 'midnight' }],
+      summary: 'test',
+    };
+    expect(validateAIOutput(raw)).toBeNull();
+  });
+
+  test('should reject invalid JSON', async () => {
+    expect(validateAIOutput('not json')).toBeNull();
+  });
+
+  test('should reject response without tasks', async () => {
+    expect(validateAIOutput({ summary: 'test' })).toBeNull();
   });
 });
 

--- a/server/tests/ai.test.js
+++ b/server/tests/ai.test.js
@@ -508,9 +508,7 @@ describe('POST /api/ai/plan/reschedule when LLM returns invalid output', () => {
     expect(res.status).toBe(422);
   });
   it('should return error message', async () => {
-    expect(res.body.error).toBe(
-      'AI tidak dapat menjadwalkan ulang saat ini. Coba lagi.',
-    );
+    expect(res.body.error).toBe('AI tidak dapat menjadwalkan ulang saat ini. Coba lagi.');
   });
 });
 
@@ -546,7 +544,7 @@ describe('POST /api/ai/plan/suggest with valid body Rate Limit', () => {
 });
 
 describe('full flow: suggest → accept → create task → verify via GET tasks', () => {
-  let suggestRes, suggestion, acceptRes, createRes, tasksRes;
+  let suggestRes, suggestion, acceptRes, createRes, tasksRes, acceptedTask;
   beforeAll(async () => {
     rateLimitConfig.disabled = true;
     suggestRes = await request(app)
@@ -562,19 +560,15 @@ describe('full flow: suggest → accept → create task → verify via GET tasks
       .set('Content-Type', 'application/json')
       .send({ status: 'accepted' });
 
+    acceptedTask = suggestion.tasks[0];
     createRes = await request(app)
       .post('/api/tasks')
       .set('Authorization', `Bearer ${token}`)
       .set('Content-Type', 'application/json')
       .send({
+        ...acceptedTask,
         goal_id: goalId,
-        title: suggestion.tasks[0].title,
-        description: suggestion.tasks[0].description,
-        duration_estimate: suggestion.tasks[0].duration_estimate,
-        planned_date: suggestion.tasks[0].planned_date,
-        planned_slot: suggestion.tasks[0].planned_slot,
         source: 'ai',
-        rationale: suggestion.tasks[0].rationale,
       });
 
     tasksRes = await request(app)
@@ -621,7 +615,10 @@ describe('full flow: suggest → accept → create task → verify via GET tasks
 
 afterAll(async () => {
   rateLimitConfig.disabled = true;
-  await db.query('DELETE FROM tasks WHERE goal_id IN (SELECT id FROM goals WHERE user_id = $1)', [userId]);
+  await db.query(
+    'DELETE FROM tasks WHERE goal_id IN (SELECT id FROM goals WHERE user_id = $1)',
+    [userId],
+  );
   await db.query('DELETE FROM goals where user_id = $1', [userId]);
   await db.query('DELETE FROM ai_recommendations where user_id = $1', [userId]);
   await db.pool.end();

--- a/server/tests/ai.test.js
+++ b/server/tests/ai.test.js
@@ -370,6 +370,151 @@ describe('PATCH /api/ai/recommendations/:id with valid body', () => {
   });
 });
 
+describe('POST /api/ai/plan/reschedule without auth', () => {
+  let res;
+  beforeAll(async () => {
+    res = await request(app)
+      .post('/api/ai/plan/reschedule')
+      .set('Content-Type', 'application/json')
+      .send({ task_ids: ['00000000-0000-0000-0000-000000000000'] });
+  });
+  it('should have 401 status code', async () => {
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /api/ai/plan/reschedule with invalid body', () => {
+  let res;
+  beforeAll(async () => {
+    res = await request(app)
+      .post('/api/ai/plan/reschedule')
+      .set('Authorization', `Bearer ${token}`)
+      .set('Content-Type', 'application/json')
+      .send({ task_ids: [] });
+  });
+  it('should have 400 status code', async () => {
+    expect(res.status).toBe(400);
+  });
+  it('Content-Type should be application/json', async () => {
+    expect(res.headers['content-type']).toBe('application/json; charset=utf-8');
+  });
+  it('should be an object', async () => {
+    expect(typeof res.body).toBe('object');
+  });
+  it('should have the error and details properties', async () => {
+    expect(res.body.error).toBe('Input tidak valid');
+    expect(typeof res.body.details).toBe('object');
+  });
+});
+
+describe('POST /api/ai/plan/reschedule with valid body', () => {
+  let res;
+  beforeAll(async () => {
+    callLLM.mockResolvedValue({
+      text: JSON.stringify({
+        tasks: [
+          {
+            id: '00000000-0000-0000-0000-000000000001',
+            title: 'Rescheduled Task',
+            duration_estimate: 45,
+            planned_date: '2026-06-08',
+            planned_slot: 'morning',
+            rationale: 'Rescheduled to available morning slot',
+          },
+        ],
+        summary: 'Rescheduled overdue tasks to this week',
+      }),
+      tokenCount: 0,
+    });
+    res = await request(app)
+      .post('/api/ai/plan/reschedule')
+      .set('Authorization', `Bearer ${token}`)
+      .set('Content-Type', 'application/json')
+      .send({ task_ids: ['00000000-0000-0000-0000-000000000000'] });
+  });
+  afterAll(() => {
+    callLLM.mockReset();
+    callLLM.mockImplementation(() =>
+      Promise.resolve({
+        text: JSON.stringify({
+          tasks: [
+            {
+              title: 'Mock Task',
+              description: 'Mock Description',
+              duration_estimate: 45,
+              planned_date: '2026-01-12',
+              planned_slot: 'morning',
+              rationale: 'Mock rationale',
+            },
+          ],
+          summary: 'Mock summary',
+        }),
+        tokenCount: 0,
+      }),
+    );
+  });
+  it('should have 200 status code', async () => {
+    expect(res.status).toBe(200);
+  });
+  it('Content-Type should be application/json', async () => {
+    expect(res.headers['content-type']).toBe('application/json; charset=utf-8');
+  });
+  it('should be an object', async () => {
+    expect(typeof res.body).toBe('object');
+  });
+  it('should return valid reschedule output schema', async () => {
+    const result = aiRescheduleOutputSchema.safeParse(res.body);
+    expect(result.success).toBe(true);
+  });
+  it('should have tasks array and summary', async () => {
+    expect(Array.isArray(res.body.tasks)).toBe(true);
+    expect(res.body.tasks.length).toBeGreaterThan(0);
+    expect(typeof res.body.summary).toBe('string');
+  });
+});
+
+describe('POST /api/ai/plan/reschedule when LLM returns invalid output', () => {
+  let res;
+  beforeAll(async () => {
+    callLLM.mockResolvedValue({ text: 'invalid{{{', tokenCount: 0 });
+    res = await request(app)
+      .post('/api/ai/plan/reschedule')
+      .set('Authorization', `Bearer ${token}`)
+      .set('Content-Type', 'application/json')
+      .send({ task_ids: ['00000000-0000-0000-0000-000000000000'] });
+  });
+  afterAll(() => {
+    callLLM.mockReset();
+    callLLM.mockImplementation(() =>
+      Promise.resolve({
+        text: JSON.stringify({
+          tasks: [
+            {
+              title: 'Mock Task',
+              description: 'Mock Description',
+              duration_estimate: 45,
+              planned_date: '2026-01-12',
+              planned_slot: 'morning',
+              rationale: 'Mock rationale',
+            },
+          ],
+          summary: 'Mock summary',
+        }),
+        tokenCount: 0,
+      }),
+    );
+  });
+  it('should have 422 status code', async () => {
+    expect(res.status).toBe(422);
+  });
+  it('should return error message', async () => {
+    expect(res.body.error).toBe(
+      'AI tidak dapat menjadwalkan ulang saat ini. Coba lagi.',
+    );
+  });
+});
+
+const { aiRescheduleOutputSchema } = require('../src/validator/ai-schema');
 const { rateLimitConfig } = require('../src/middleware/rateLimiter.js');
 describe('POST /api/ai/plan/suggest with valid body Rate Limit', () => {
   let res;

--- a/server/tests/ai.test.js
+++ b/server/tests/ai.test.js
@@ -545,8 +545,83 @@ describe('POST /api/ai/plan/suggest with valid body Rate Limit', () => {
   });
 });
 
+describe('full flow: suggest → accept → create task → verify via GET tasks', () => {
+  let suggestRes, suggestion, acceptRes, createRes, tasksRes;
+  beforeAll(async () => {
+    rateLimitConfig.disabled = true;
+    suggestRes = await request(app)
+      .post('/api/ai/plan/suggest')
+      .set('Authorization', `Bearer ${token}`)
+      .set('Content-Type', 'application/json')
+      .send({ goal_id: goalId, week_start: '2026-01-12' });
+    suggestion = suggestRes.body;
+
+    acceptRes = await request(app)
+      .patch('/api/ai/recommendations/latest')
+      .set('Authorization', `Bearer ${token}`)
+      .set('Content-Type', 'application/json')
+      .send({ status: 'accepted' });
+
+    createRes = await request(app)
+      .post('/api/tasks')
+      .set('Authorization', `Bearer ${token}`)
+      .set('Content-Type', 'application/json')
+      .send({
+        goal_id: goalId,
+        title: suggestion.tasks[0].title,
+        description: suggestion.tasks[0].description,
+        duration_estimate: suggestion.tasks[0].duration_estimate,
+        planned_date: suggestion.tasks[0].planned_date,
+        planned_slot: suggestion.tasks[0].planned_slot,
+        source: 'ai',
+        rationale: suggestion.tasks[0].rationale,
+      });
+
+    tasksRes = await request(app)
+      .get('/api/tasks?week_start=2026-01-12')
+      .set('Authorization', `Bearer ${token}`);
+  });
+  afterAll(async () => {
+    if (createRes?.body?.id) {
+      await db.query('DELETE FROM tasks WHERE id = $1', [createRes.body.id]);
+    }
+  });
+  it('suggest should return 200', async () => {
+    expect(suggestRes.status).toBe(200);
+  });
+  it('suggest should return tasks array and summary', async () => {
+    expect(Array.isArray(suggestion.tasks)).toBe(true);
+    expect(suggestion.tasks.length).toBeGreaterThan(0);
+    expect(typeof suggestion.summary).toBe('string');
+  });
+  it('accept should return 200', async () => {
+    expect(acceptRes.status).toBe(200);
+  });
+  it('accept should return status accepted', async () => {
+    expect(acceptRes.body.status).toBe('accepted');
+  });
+  it('create task should return 201', async () => {
+    expect(createRes.status).toBe(201);
+  });
+  it('create task should return task with correct title', async () => {
+    expect(createRes.body.title).toBe(suggestion.tasks[0].title);
+  });
+  it('get tasks should return 200', async () => {
+    expect(tasksRes.status).toBe(200);
+  });
+  it('get tasks should return grouped object', async () => {
+    expect(tasksRes.body).toHaveProperty('week_start');
+    expect(tasksRes.body).toHaveProperty('tasks');
+  });
+  it('get tasks should include created task', async () => {
+    const allTasks = Object.values(tasksRes.body.tasks).flat();
+    expect(allTasks.some((t) => t.id === createRes.body.id)).toBe(true);
+  });
+});
+
 afterAll(async () => {
   rateLimitConfig.disabled = true;
+  await db.query('DELETE FROM tasks WHERE goal_id IN (SELECT id FROM goals WHERE user_id = $1)', [userId]);
   await db.query('DELETE FROM goals where user_id = $1', [userId]);
   await db.query('DELETE FROM ai_recommendations where user_id = $1', [userId]);
   await db.pool.end();

--- a/server/tests/progress.test.js
+++ b/server/tests/progress.test.js
@@ -28,13 +28,14 @@ afterAll(async () => {
   await db.pool.end();
 });
 
-beforeEach(async () => {
-  // Clean tasks and snapshots before each test
-  await db.query('DELETE FROM tasks WHERE goal_id = $1', [goalId]);
-  await db.query('DELETE FROM progress_snapshots WHERE user_id = $1', [userId]);
-});
+const request = require('supertest');
+const app = require('../src/app');
 
 describe('recalculateProgress', () => {
+  beforeEach(async () => {
+    await db.query('DELETE FROM tasks WHERE goal_id = $1', [goalId]);
+    await db.query('DELETE FROM progress_snapshots WHERE user_id = $1', [userId]);
+  });
   test('menghitung completion rate dengan benar', async () => {
     // 3 tasks: 2 done, 1 todo
     await db.query(
@@ -77,5 +78,146 @@ describe('recalculateProgress', () => {
     const result = await recalculateProgress(userId, testDate);
     // actual (60) > estimate (30), tapi rate tetap max 1.0
     expect(parseFloat(result.completion_rate)).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('GET /api/progress/weekly without auth', () => {
+  let res;
+  beforeAll(async () => {
+    res = await request(app)
+      .get('/api/progress/weekly')
+      .query({ week: '2026-W16' });
+  });
+  it('should have 401 status code', async () => {
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/progress/weekly without week param', () => {
+  let token, res;
+  beforeAll(async () => {
+    const loginRes = await request(app)
+      .post('/api/auth/login')
+      .set('Content-Type', 'application/json')
+      .send({ email: 'progress-test@test.com', password: 'test12345678' });
+    token = loginRes.body.token;
+    res = await request(app)
+      .get('/api/progress/weekly')
+      .set('Authorization', `Bearer ${token}`);
+  });
+  it('should have 400 status code', async () => {
+    expect(res.status).toBe(400);
+  });
+  it('should return error message', async () => {
+    expect(res.body.error).toBe('Parameter week diperlukan (format: YYYY-Wxx)');
+  });
+});
+
+describe('GET /api/progress/weekly with non-existent week', () => {
+  let token, res;
+  beforeAll(async () => {
+    const loginRes = await request(app)
+      .post('/api/auth/login')
+      .set('Content-Type', 'application/json')
+      .send({ email: 'progress-test@test.com', password: 'test12345678' });
+    token = loginRes.body.token;
+    res = await request(app)
+      .get('/api/progress/weekly')
+      .set('Authorization', `Bearer ${token}`)
+      .query({ week: '2026-W99' });
+  });
+  it('should have 200 status code', async () => {
+    expect(res.status).toBe(200);
+  });
+  it('should return zeros', async () => {
+    expect(res.body).toMatchObject({
+      week: '2026-W99',
+      planned_hours: 0,
+      completed_hours: 0,
+      completion_rate: 0,
+    });
+  });
+});
+
+describe('GET /api/progress/weekly with valid week', () => {
+  let token, res;
+  beforeAll(async () => {
+    await db.query('DELETE FROM tasks WHERE goal_id = $1', [goalId]);
+    await db.query('DELETE FROM progress_snapshots WHERE user_id = $1', [userId]);
+    const loginRes = await request(app)
+      .post('/api/auth/login')
+      .set('Content-Type', 'application/json')
+      .send({ email: 'progress-test@test.com', password: 'test12345678' });
+    token = loginRes.body.token;
+    await db.query(
+      `INSERT INTO tasks (goal_id, title, duration_estimate, planned_date, planned_slot, status) VALUES
+       ($1, 'Task 1', 60, $2, 'morning', 'done'),
+       ($1, 'Task 2', 30, $2, 'afternoon', 'todo')`,
+      [goalId, '2026-04-14'],
+    );
+    await recalculateProgress(userId, '2026-04-14');
+    res = await request(app)
+      .get('/api/progress/weekly')
+      .set('Authorization', `Bearer ${token}`)
+      .query({ week: '2026-W16' });
+  });
+  it('should have 200 status code', async () => {
+    expect(res.status).toBe(200);
+  });
+  it('should return progress object', async () => {
+    expect(res.body).toHaveProperty('week');
+    expect(res.body).toHaveProperty('planned_hours');
+    expect(res.body).toHaveProperty('completed_hours');
+    expect(res.body).toHaveProperty('completion_rate');
+  });
+  it('should have correct planned_hours', async () => {
+    expect(parseFloat(res.body.planned_hours)).toBe(1.5);
+  });
+});
+
+describe('GET /api/progress/trend without auth', () => {
+  let res;
+  beforeAll(async () => {
+    res = await request(app).get('/api/progress/trend');
+  });
+  it('should have 401 status code', async () => {
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/progress/trend', () => {
+  let token, res;
+  beforeAll(async () => {
+    await db.query('DELETE FROM tasks WHERE goal_id = $1', [goalId]);
+    await db.query('DELETE FROM progress_snapshots WHERE user_id = $1', [userId]);
+    const loginRes = await request(app)
+      .post('/api/auth/login')
+      .set('Content-Type', 'application/json')
+      .send({ email: 'progress-test@test.com', password: 'test12345678' });
+    token = loginRes.body.token;
+    await db.query(
+      `INSERT INTO tasks (goal_id, title, duration_estimate, planned_date, planned_slot, status) VALUES
+       ($1, 'Task 1', 60, $2, 'morning', 'done')`,
+      [goalId, '2026-04-14'],
+    );
+    await recalculateProgress(userId, '2026-04-14');
+    res = await request(app)
+      .get('/api/progress/trend')
+      .set('Authorization', `Bearer ${token}`);
+  });
+  it('should have 200 status code', async () => {
+    expect(res.status).toBe(200);
+  });
+  it('should be an array', async () => {
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+  it('each entry should have week, planned, completed, rate', async () => {
+    if (res.body.length > 0) {
+      const entry = res.body[0];
+      expect(entry).toHaveProperty('week');
+      expect(entry).toHaveProperty('planned');
+      expect(entry).toHaveProperty('completed');
+      expect(entry).toHaveProperty('rate');
+    }
   });
 });

--- a/server/tests/progress.test.js
+++ b/server/tests/progress.test.js
@@ -1,0 +1,81 @@
+require('dotenv').config();
+const db = require('../src/utils/db');
+const { recalculateProgress } = require('../src/models/progress_snapshots.js');
+const bcrypt = require('bcryptjs');
+
+let userId, goalId;
+const testDate = '2026-04-15'; // Selasa
+
+beforeAll(async () => {
+  // Create test user
+  const hash = await bcrypt.hash('test12345678', 10);
+  const userResult = await db.query(
+    "INSERT INTO users (email, password_hash) VALUES ('progress-test@test.com', $1) RETURNING id",
+    [hash],
+  );
+  userId = userResult.rows[0].id;
+  await db.query('INSERT INTO profiles (user_id) VALUES ($1)', [userId]);
+  // Create test goal
+  const goalResult = await db.query(
+    'INSERT INTO goals (user_id, title) VALUES ($1, $2) RETURNING id',
+    [userId, 'Test Goal'],
+  );
+  goalId = goalResult.rows[0].id;
+});
+
+afterAll(async () => {
+  await db.query("DELETE FROM users WHERE email = 'progress-test@test.com'");
+  await db.pool.end();
+});
+
+beforeEach(async () => {
+  // Clean tasks and snapshots before each test
+  await db.query('DELETE FROM tasks WHERE goal_id = $1', [goalId]);
+  await db.query('DELETE FROM progress_snapshots WHERE user_id = $1', [userId]);
+});
+
+describe('recalculateProgress', () => {
+  test('menghitung completion rate dengan benar', async () => {
+    // 3 tasks: 2 done, 1 todo
+    await db.query(
+      `INSERT INTO tasks (goal_id, title, duration_estimate, planned_date, planned_slot, status, actual_duration) VALUES
+       ($1, 'Task 1', 60, $2, 'morning', 'done', 45),
+       ($1, 'Task 2', 30, $2, 'afternoon', 'done', NULL),
+       ($1, 'Task 3', 60, $2, 'evening', 'todo', NULL)`,
+      [goalId, testDate],
+    );
+    const result = await recalculateProgress(userId, testDate);
+    expect(parseFloat(result.planned_hours)).toBeCloseTo(2.5); // (60+30+60)/60
+    expect(parseFloat(result.completed_hours)).toBeCloseTo(1.25); // (45+30)/60
+    expect(parseFloat(result.completion_rate)).toBeCloseTo(0.5);
+  });
+
+  test('menggunakan actual_duration jika tersedia, fallback ke estimate', async () => {
+    await db.query(
+      `INSERT INTO tasks (goal_id, title, duration_estimate, planned_date, planned_slot, status, actual_duration) VALUES
+       ($1, 'Task 1', 60, $2, 'morning', 'done', 90),
+       ($1, 'Task 2', 45, $2, 'afternoon', 'done', NULL)`,
+      [goalId, testDate],
+    );
+    const result = await recalculateProgress(userId, testDate);
+    expect(parseFloat(result.completed_hours)).toBeCloseTo(2.25); // (90+45)/60
+  });
+
+  test('mengembalikan 0 jika tidak ada tasks', async () => {
+    const result = await recalculateProgress(userId, testDate);
+    expect(parseFloat(result.planned_hours)).toBe(0);
+    expect(parseFloat(result.completed_hours)).toBe(0);
+    expect(parseFloat(result.completion_rate)).toBe(0);
+  });
+
+  test('completion_rate tidak melebihi 1.0', async () => {
+    await db.query(
+      `INSERT INTO tasks (goal_id, title, duration_estimate, planned_date, planned_slot, status, actual_duration) VALUES
+       ($1, 'Task 1', 30, $2, 'morning', 'done', 60)`,
+      [goalId, testDate],
+    );
+    const result = await recalculateProgress(userId, testDate);
+    // actual (60) > estimate (30), tapi rate tetap max 1.0
+    expect(parseFloat(result.completion_rate)).toBeLessThanOrEqual(1);
+  });
+});

--- a/server/tests/tasks.test.js
+++ b/server/tests/tasks.test.js
@@ -306,7 +306,6 @@ describe('PATCH /api/tasks/:id/status from `done` to `todo`', () => {
       .send({
         status: 'todo',
       });
-    console.log(res.body);
   });
   it('should have 400 status code', async () => {
     expect(res.status).toBe(400);

--- a/server/tests/tasks.test.js
+++ b/server/tests/tasks.test.js
@@ -277,6 +277,45 @@ describe('PATCH /api/tasks/:id with valid body', () => {
   });
 });
 
+describe('PATCH /api/tasks/:id/status from `todo` to `done`', () => {
+  let res;
+  beforeAll(async () => {
+    res = await request(app)
+      .patch(`/api/tasks/${taskId}/status`)
+      .set('Authorization', `Bearer ${token}`)
+      .set('Content-Type', 'application/json')
+      .send({
+        status: 'done',
+      });
+  });
+  it('should have 200 status code', async () => {
+    expect(res.status).toBe(200);
+  });
+  it('should have status of done', async () => {
+    expect(res.body.status).toBe('done');
+  });
+});
+
+describe('PATCH /api/tasks/:id/status from `done` to `todo`', () => {
+  let res;
+  beforeAll(async () => {
+    res = await request(app)
+      .patch(`/api/tasks/${taskId}/status`)
+      .set('Authorization', `Bearer ${token}`)
+      .set('Content-Type', 'application/json')
+      .send({
+        status: 'todo',
+      });
+    console.log(res.body);
+  });
+  it('should have 400 status code', async () => {
+    expect(res.status).toBe(400);
+  });
+  it("should have error message of \"Transisi dari 'done' ke 'todo' tidak diperbolehkan.\"", async () => {
+    expect(res.body.error).toBe("Transisi dari 'done' ke 'todo' tidak diperbolehkan.");
+  });
+});
+
 afterAll(async () => {
   await db.query('DELETE FROM goals where user_id = $1', [userId]);
   await db.pool.end();


### PR DESCRIPTION
- **fix(server): ensure validateAIOutput can receive object**
- **test(server): refine validateAIOutput (closes #68)**
- **test(server): add recalculateProgress test (closes #69)**
- **test(server): task status transition (closes #77)**
- **fix(server/routes): remove duplicate reschedule**
- **chore(server/test/task): remove console log**
- **test(server/ai): reschedule (closes #78)**
- **test(config): set coverageThreshold to 50%, closes #79**
- **test(server/progress): add route tests**
- **test(server): suggest → accept → create task → verify, closes #70**
- **test(server/ai): shorten the full flow test, format file**
